### PR TITLE
Documentation KV Create/upload key, upload binary data or file with line breaks via curl

### DIFF
--- a/website/source/api/kv.html.md
+++ b/website/source/api/kv.html.md
@@ -197,12 +197,19 @@ The table below shows this endpoint's support for
 
 The payload is arbitrary, and is loaded directly into Consul as supplied.
 
-### Sample Request
+### Sample Requests
 
-```text
+```bash
 $ curl \
     --request PUT \
     --data @contents \
+    https://consul.rocks/v1/kv/my-key
+
+# or
+
+$ curl \
+    --request PUT \
+    --data-binary @contents \
     https://consul.rocks/v1/kv/my-key
 ```
 


### PR DESCRIPTION
Hi,
when I was experimenting with upload of YAML configuration to consul I noticed that line breaks went missing. I think it might be useful to provide information about different way of uploading via `curl`.

I'm not sure if I should add anything to markdown, option `--data-binary` seems to be self-explanatory.